### PR TITLE
Updated example link in spec page to match review checklist

### DIFF
--- a/spec_page_template.md
+++ b/spec_page_template.md
@@ -6,8 +6,8 @@ summary: "Change to the Jakarta Wombat spec for feature X."
 ---
 Jakarta Wombat defines server-side handling for HTTP requests and responses.
 
-* [Jakarta Wombat 1.0 Specification Document](./wombat-spec_1.0.pdf) (PDF)
-* [Jakarta Wombat 1.0 Specification Document](./wombat-spec_1.0.html) (HTML)
+* [Jakarta Wombat 1.0 Specification Document](./wombat-spec-1.0.pdf) (PDF)
+* [Jakarta Wombat 1.0 Specification Document](./wombat-spec-1.0.html) (HTML)
 * [Jakarta Wombat 1.0 Javadoc](./apidocs)
 * [Jakarta Wombat 1.0 TCK](http://downloads.eclipse.org/jakarta/wombat/1.0.0/wombat-tck-1.0.0.zip)
 * Maven coordinates


### PR DESCRIPTION
The template for the spec page suggested using the form
{name}-spec_x.y.{extension} but the review checklist was using
{name}-spec-x.y.{extension}. Most people followed the review checklist.
The [JAX-RS PR](https://github.com/jakartaee/specifications/pull/7)
originally followed the spec page format. So making the template spec
page match the review checklist since that is what seems to be the
majority case.