### PR TITLE
Update jstl spec code to tags

### DIFF
--- a/names.adoc
+++ b/names.adoc
@@ -153,7 +153,7 @@
 |{projectBaseURL}/ee4j.jstl[ee4j.jstl]
 |Jakarta Standard Tag Library
 |{gitBaseURL}/jstl-api[Jakarta Standard Tag Library]
-|jstl
+|tags
 
 |{projectBaseURL}/ee4j.jta[ee4j.jta]
 |Jakarta Transactions


### PR DESCRIPTION
There was a transcription error from the spreadsheet to here which is being fixed. This means that JSTL as the spec short code is changed to tags.