### PR TITLE
explain the 'date:' field in the checklist and template

### DIFF
--- a/spec_finalization_checklist.md
+++ b/spec_finalization_checklist.md
@@ -17,7 +17,7 @@ pointers to the PR request containing the proposed release content (e.g. release
   * A specification committee member votes by responding to the ballot message on the public Jakarta EE Specification Committee mailing list, using the usual +1/0/-1 voting notation.
 * On ballot completion
  - [ ] The designated specification committee representative adds this final checklist to the main PR.
- - [ ] The specification committee representative merges the specification and apidocs PRs.
+ - [ ] The specification committee representative merges the specification and apidocs PRs, ensuring the "date:" field in the _index.md file has an appropriate value to allow publishing.
  - [ ] The designated specification committee representative calculates the staged EFTL TCK signature and promotes it to the committee download area
   using the https://ci.eclipse.org/jakartaee-spec-committee/job/promote-release/ job.
  - [ ] The specification project member who created the staging release promotes the specification api jars to maven central. An example release job script can be found here https://wiki.eclipse.org/MavenReleaseScript.

--- a/spec_page_template.md
+++ b/spec_page_template.md
@@ -1,4 +1,5 @@
 <!-- Template for the root page of a specification release -->
+<!-- The "date:" field is used as a "publish" date for the automated Hugo processing -->
 ---
 title: "Jakarta Wombat Spec 1.0"
 date: YYYY-MM-DD
@@ -13,6 +14,11 @@ Jakarta Wombat defines server-side handling for HTTP requests and responses.
 * [Jakarta Wombat 1.0 TCK](http://downloads.eclipse.org/jakarta/wombat/1.0.0/wombat-tck-1.0.0.zip)
 * Maven coordinates
   * [jakarta.wombat:jakarta.wombat-api:jar:1.0.0](https://search.maven.org/artifact/jakarta.wombat/jakarta.wombat-api/1.0.0/jar)
+
+# Compatible Implementations
+
+* [Apache Marsupials 5.7](https://apache.org/marsupials)
+* [Eclipse Vombatidae 9.1.1](https://github.com/eclipse-ee4j/vombatidae)
 
 # Ballots
 
@@ -47,8 +53,3 @@ The Plan Review Specification Committee Ballot concluded successfully on 2019-09
 |EE4J PMC               | &check; |     |          |
 |Participant Members    | &check; |     |          |
 |Committer Members      | &check; |     |          |
-
-# Compatible Implementations
-
-* [Apache Marsupials 5.7](https://apache.org/marsupials)
-* [Eclipse Vombatidae 9.1.1](https://github.com/eclipse-ee4j/vombatidae)


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Per the Spec Committee call today, I added a short item to the final checklist that reminds us to review the date: field in case we missed it during the initial review process.

When I was adding a similar comment to the Specification Page template, I noticed that the template didn't have the Compatible Implementations section in the right location.  So, I fixed that as well.