### PR TITLE
Create Change Log Template

### DIFF
--- a/changelog_page_template.md
+++ b/changelog_page_template.md
@@ -1,0 +1,35 @@
+<!-- Template for the change log page of a specification release -->
+<!-- The "date:" field is used as a "publish" date for the automated Hugo processing -->
+---
+title: "Change Log"
+date: YYYY-MM-DD
+summary: "Wombat 1.0 Change Log"
+---
+
+<!-- Please describe the service release changes made to Jakarta Wombat 1.0. --> 
+<!-- The intent is to provide clarity about what has changed in each API and TCK service release. -->
+<!-- It is not necessary to create this file for the initial release of a specification. -->
+
+# API Changes
+
+## CHANGES IN THE 1.0.1 RELEASE
+
+<!-- Provide a bullet point list of the fixed issues or other changes -->
+
+* https://github.com/jakartaee/wombat/issues/231
+
+# TCK Changes
+
+## CHANGES IN THE 1.0.1 RELEASE
+
+### Addressed Issues
+
+<!-- Provide a bullet point list of the addressed TCK challenge and issue URLs -->
+
+* https://github.com/jakartaee/wombat/issues/123
+
+### Other Changes
+
+<!-- Provide a bullet point list of any other miscellaneous changes resolved in this release -->
+
+* https://github.com/jakartaee/wombat/issues/321


### PR DESCRIPTION
Follow-up to Spec Committee Issue 83: https://github.com/jakartaee/specification-committee/issues/83

It was raised that there should be a way to see what the difference between the various TCK releases are.
The changelog file mechanism already exists, so this is a draft example of how we may update the format of this file to separate out TCK changes from API changes.

Counterpart to https://github.com/jakartaee/specifications/pull/902